### PR TITLE
v2.1.0: Доработки и исправления

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### v2.1.0
+
+- [*] исправлено определение window.notifications_enabled ([issue](https://github.com/ktsstudio/mediaproject-vk/issues/11))
+- [*] исправлено определение window.is_ios и window.is_android в mvk ([issue](https://github.com/ktsstudio/mediaproject-vk/issues/13))
+- [*] исправлено определение того, что приложение открыто на Android ([issue](https://github.com/ktsstudio/mediaproject-vk/issues/14))
+- [*] расширена поддержка react до версии 18 ([issue](https://github.com/ktsstudio/mediaproject-vk/issues/12))
+- [+] добавлена возможность указания типа ответа для функции callVkApi
+
 ## v2.0.0
 
 - [-] удалены утилиты, которые не несли смысловой нагрузки и являлись просто оберткой try catch над вызовом метода VK ([issue](https://github.com/ktsstudio/mediaproject-vk/issues/5))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### v2.1.0
 
+- [*] дополнена обработка сообщений из API VK об отказе пользователя от какого-либо действия
 - [*] исправлено определение window.notifications_enabled ([issue](https://github.com/ktsstudio/mediaproject-vk/issues/11))
 - [*] исправлено определение window.is_ios и window.is_android в mvk ([issue](https://github.com/ktsstudio/mediaproject-vk/issues/13))
 - [*] исправлено определение того, что приложение открыто на Android ([issue](https://github.com/ktsstudio/mediaproject-vk/issues/14))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
-### v2.1.0
+## v2.1.0
 
-- [*] дополнена обработка сообщений из API VK об отказе пользователя от какого-либо действия
 - [*] исправлено определение window.notifications_enabled ([issue](https://github.com/ktsstudio/mediaproject-vk/issues/11))
 - [*] исправлено определение window.is_ios и window.is_android в mvk ([issue](https://github.com/ktsstudio/mediaproject-vk/issues/13))
 - [*] исправлено определение того, что приложение открыто на Android ([issue](https://github.com/ktsstudio/mediaproject-vk/issues/14))
 - [*] расширена поддержка react до версии 18 ([issue](https://github.com/ktsstudio/mediaproject-vk/issues/12))
 - [+] добавлена возможность указания типа ответа для функции callVkApi
+- [*] поднята версия @ktsstudio/mediaproject-utils до 4.1.1
 
-## v2.0.0
+### v2.0.1
+
+- [+] checkVkUserDenied: добавлена обработка нового кода ошибки от ВК в случае отказа от ручного действия
+
+# v2.0.0
 
 - [-] удалены утилиты, которые не несли смысловой нагрузки и являлись просто оберткой try catch над вызовом метода VK ([issue](https://github.com/ktsstudio/mediaproject-vk/issues/5))
 - [*] изменен метод вызова VK API через bridge, в него добавлена проверка на ошибки токена и возможность ретрая в их случае
@@ -22,11 +26,11 @@
 - [*] улучшены JSDoc
 - [*] хук useEventSubscribe передает полученный event в callback ([issue](https://github.com/ktsstudio/mediaproject-vk/issues/1))
 
-#### v1.2.1
+### v1.2.1
 
-- [*] @ktsstudio/mediaprojetc-utils@4.0.0
+- [*] @ktsstudio/mediaproject-utils@4.0.0
 
-### v1.2.0
+## v1.2.0
 
 - [+] useEventSubscribe
 - [+] usePolling
@@ -34,47 +38,47 @@
 - [*] getAuthToken проверяет наличие всех скоупов в ответе
 - [+] isAvatarDefault
 
-### v1.1.0
+## v1.1.0
 
 - [+] checkMobile
 - [*] checkIOS: add platform 'mobile_ipad', adding classname 'android'
 - [*] fix JSDoc syntax
 
-#### v1.0.12
+### v1.0.12
 
 - [*] swipe back
 - [*] view settings
 
-#### v1.0.11
+### v1.0.11
 
 - [+] odr param in window
 
-#### v1.0.10
+### v1.0.10
 
 - [*] params
 
-#### v1.0.9
+### v1.0.9
 
 - [*] sharePost: wrapped try catch
 - [*] shareStory: wrapped try catch
 
-#### v1.0.8
+### v1.0.8
 
 - [*] getUserInfo: wrapped try catch
 
-#### v1.0.7
+### v1.0.7
 
 - [*] getAuthToken: added exception handling, changed returned value
 
-#### v1.0.6
+### v1.0.6
 
 - [*] initializeVkApp
 
-#### v1.0.5
+### v1.0.5
 
 - [*] README
 
-#### v1.0.4
+### v1.0.4
 
 - [+] types moved to src/types
 - [*] Window type inherited
@@ -82,19 +86,19 @@
 - [+] checkIOS
 - [*] README
 
-#### v1.0.3
+### v1.0.3
 
 - [*] Code style
 
-#### v1.0.2
+### v1.0.2
 
 - [*] Code style
 
-#### v1.0.1
+### v1.0.1
 
 [+] Метод для инициализации приложения с получением квери-параметров и отправки VKWebAppInit
 
-## v1.0.0
+# v1.0.0
 
 [+] Обертки для методов:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ktsstudio/mediaproject-vk",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Package with utils for VK Mini Apps",
   "author": "KTS Studio <hello@ktsstudio.ru> (https://kts.studio)",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
-    "@ktsstudio/mediaproject-utils": "^4.0.0",
+    "@ktsstudio/mediaproject-utils": "^4.1.1",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-commonjs": "^24.0.1",
     "@rollup/plugin-node-resolve": "^15.0.1",
@@ -72,7 +72,7 @@
     "typescript": "^4.1.3"
   },
   "peerDependencies": {
-    "@ktsstudio/mediaproject-utils": "^4.0.0",
+    "@ktsstudio/mediaproject-utils": "^4.1.1",
     "@types/react": ">=17",
     "@vkontakte/vk-bridge": "^2.7.2",
     "react": ">=17"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@rollup/plugin-terser": "^0.4.0",
     "@rollup/plugin-typescript": "^11.0.0",
     "@types/node": "^16.4.0",
-    "@types/react": "^17.0.2",
+    "@types/react": ">=17",
     "@typescript-eslint/eslint-plugin": "^4.13.0",
     "@typescript-eslint/parser": "^4.14.1",
     "@vkontakte/vk-bridge": "^2.7.2",
@@ -66,15 +66,15 @@
     "husky": "^7.0.1",
     "lint-staged": "^11.0.0",
     "prettier": "^2.2.1",
-    "react": "^17.0.2",
+    "react": ">=17",
     "rollup": "^3.10.1",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "typescript": "^4.1.3"
   },
   "peerDependencies": {
     "@ktsstudio/mediaproject-utils": "^4.0.0",
-    "@types/react": "^17.0.2",
+    "@types/react": ">=17",
     "@vkontakte/vk-bridge": "^2.7.2",
-    "react": "^17.0.2"
+    "react": ">=17"
   }
 }

--- a/src/callVkApi.ts
+++ b/src/callVkApi.ts
@@ -28,18 +28,19 @@ const VK_TOKEN_ERRORS = [
  * @param {string|null} [props.accessToken=null] Ключ доступа для обращения к API. Если не передан, будет получен вызовом функции {@link getVkAccessToken} с передчаей в нее параметров из getAccessTokenParams.
  * @param {string} [props.renewTokenIfExpired=true] Нужно ли получить новый токен доступа и повторить запрос в случае, если срок действия токена закончился. Если указан как true, то при получении от API ошибки одной из {@link VK_TOKEN_ERRORS} будет вызван метод {@link getNewVkAccessToken} с аргументом getAccessTokenParams.
  * @param {Object} [props.getAccessTokenParams={}] Параметры для получения токена доступа, которые будут переданы в {@link getVkAccessToken} в случае, если токена нет, или в {@link getNewVkAccessToken}, если срок действия токена закончился (если передано значение true для renewTokenIfExpired).
- * @returns {Promise<CallVkApiResponseType>} Возвращает ответ, полученный на запрос VKWebAppCallAPIMethod с переданными параметрами.
+ * @returns {Promise<CallVkApiResponseType>} Возвращает ответ, полученный на запрос VKWebAppCallAPIMethod с переданными параметрами. Поле результата response, присутствующее в случае успешного запроса, может быть типизировано с помощью дженерика
  *
  * @see {@link https://dev.vk.com/bridge/VKWebAppCallAPIMethod|VKWebAppCallAPIMethod}
  */
-const callVkApi = async ({
+// eslint-disable-next-line
+const callVkApi = async <D = any>({
   method,
   params = {},
   version = '5.131',
   accessToken = null,
   renewTokenIfExpired = true,
   getAccessTokenParams = {},
-}: CallVkApiPropsType): Promise<CallVkApiResponseType> => {
+}: CallVkApiPropsType): Promise<CallVkApiResponseType<D>> => {
   try {
     let token: string | null = accessToken;
 

--- a/src/checkVkPlatform.ts
+++ b/src/checkVkPlatform.ts
@@ -144,14 +144,14 @@ const checkVkPlatform = (
   document.body.classList.add(VK_PLATFORM_CLASSNAME.mvk);
 
   if (/(iPad|iPhone|iPod)/g.test(navigator.userAgent)) {
-    window.is_ios;
+    window.is_ios = true;
     document.body.classList.add(VK_PLATFORM_CLASSNAME.ios);
 
     return;
   }
 
   if (/android/i.test(navigator.userAgent)) {
-    window.is_android;
+    window.is_android = true;
     document.body.classList.add(VK_PLATFORM_CLASSNAME.android);
 
     return;

--- a/src/checkVkPlatform.ts
+++ b/src/checkVkPlatform.ts
@@ -26,9 +26,9 @@ const IOS_VK_PLATFORMS: VkPlatformType[] = [
  * @constant {VkPlatformType[]}
  */
 const ANDROID_VK_PLATFORMS: VkPlatformType[] = [
-  'mobile_ipad',
-  'mobile_iphone',
-  'mobile_iphone_messenger',
+  'mobile_android',
+  'mobile_android_messenger',
+  'android_external',
 ];
 
 /**

--- a/src/checkVkUserDenied.ts
+++ b/src/checkVkUserDenied.ts
@@ -1,5 +1,7 @@
 import { ErrorData } from '@vkontakte/vk-bridge';
 
+const userDeniedReasons = new Set(['User denied', 'Operation denied by user']);
+
 /**
  * Утилита для проверки, что пришедшая от API ВКонтакте ошибка,
  * получена в результате отказа пользователя от какого-либо необходимого действия.
@@ -8,10 +10,16 @@ import { ErrorData } from '@vkontakte/vk-bridge';
  * @param {ErrorData} error Ошибка, полученная от API ВКонтакте.
  * @returns {boolean} Если действительно ошибка возникла по причине отказа пользователя, возвращает true. Иначе возвращает false.
  */
-const checkVkUserDenied = (error: ErrorData): boolean =>
-  error?.error_type === 'client_error' &&
-  (error?.error_data?.error_reason === 'User denied' ||
-    error?.error_data?.error_reason === 'Operation denied by user') &&
-  error?.error_data.error_code === 4;
+const checkVkUserDenied = (error: ErrorData): boolean => {
+  if (!error || !error.error_data || error.error_type !== 'client_error') {
+    return false;
+  }
+
+  const {
+    error_data: { error_reason, error_code },
+  } = error;
+
+  return error_code === 4 && userDeniedReasons.has(error_reason);
+};
 
 export { checkVkUserDenied };

--- a/src/checkVkUserDenied.ts
+++ b/src/checkVkUserDenied.ts
@@ -10,6 +10,8 @@ import { ErrorData } from '@vkontakte/vk-bridge';
  */
 const checkVkUserDenied = (error: ErrorData): boolean =>
   error?.error_type === 'client_error' &&
-  error?.error_data?.error_reason === 'User denied';
+  (error?.error_data?.error_reason === 'User denied' ||
+    error?.error_data?.error_reason === 'Operation denied by user') &&
+  error?.error_data.error_code === 4;
 
 export { checkVkUserDenied };

--- a/src/initializeVkApp.ts
+++ b/src/initializeVkApp.ts
@@ -23,9 +23,8 @@ const initializeVkApp = async (): Promise<InitializeVkAppResponseType> => {
 
   window.user_id = Number(findGetParameter('vk_user_id'));
   window.app_id = Number(findGetParameter('vk_app_id'));
-  window.notifications_enabled = Boolean(
-    findGetParameter('vk_are_notifications_enabled')
-  );
+  window.notifications_enabled =
+    findGetParameter('vk_are_notifications_enabled') === '1';
   window.language = findGetParameter('vk_language') || undefined;
   window.ref = findGetParameter('vk_ref') || undefined;
   window.scope = findGetParameter('vk_access_token_settings') || undefined;

--- a/src/types/callVkApi.ts
+++ b/src/types/callVkApi.ts
@@ -1,6 +1,5 @@
-import { RequestPropsMap } from '@vkontakte/vk-bridge';
+import { ErrorData, RequestPropsMap } from '@vkontakte/vk-bridge';
 
-import { VkResponseType } from './common';
 import { GetVkAccessTokenParamsType } from './getVkAccessToken';
 
 type CallVkApiRequestBasePropsType = RequestPropsMap['VKWebAppCallAPIMethod'];
@@ -22,7 +21,11 @@ type CallVkApiPropsType = {
   accessToken?: CallVkApiRequestBasePropsType['params']['access_token'] | null;
 } & CallVkApiAccessTokenPropsType;
 
-type CallVkApiResponseType = VkResponseType<'VKWebAppCallAPIMethod'>;
+type CallVkApiResponseType<D> = Partial<
+  {
+    response: D;
+  } & ErrorData
+>;
 
 export type {
   CallVkApiRequestBasePropsType,

--- a/src/types/shareVkPost.ts
+++ b/src/types/shareVkPost.ts
@@ -36,13 +36,13 @@ type UploadFromApiToVkResponseType = ApiResponse<{
   };
 }>;
 
-type SaveVkWallPhotoResponseType = Omit<CallVkApiResponseType, 'response'> & {
-  response?: {
+type SaveVkWallPhotoResponseType = CallVkApiResponseType<
+  {
     id: number;
     album_id: number;
     owner_id: number;
-  }[];
-};
+  }[]
+>;
 
 export type {
   ShareVkPostPropsType,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1009,12 +1009,12 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@ktsstudio/mediaproject-utils@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@ktsstudio/mediaproject-utils/-/mediaproject-utils-4.0.0.tgz#d6cd5c8f5802198660f1ee66c1806e021fe8ca11"
-  integrity sha512-iBIpVTQQgtPZ08kU/hGuYDx8fv7jpNBjybn+ikucNJDMRz1CCDoAWmTKtU1oT20nMCaI51MYiPPEykSJXVSOQw==
+"@ktsstudio/mediaproject-utils@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@ktsstudio/mediaproject-utils/-/mediaproject-utils-4.1.1.tgz#e14e2c03c1d3222ea537d8eac29880ea7ed9c25a"
+  integrity sha512-PsOEThipc+IBucRcphdePSJKs0ERFpZEIwpmCbTAYjsSNgHjh0+C+M0ni3DM0V0qNOj4SH9qDwl1jWrpo5o50A==
   dependencies:
-    axios "^0.21.1"
+    axios "^0.24.0"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1334,12 +1334,12 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
-axios@^0.21.1:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+axios@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
+  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
   dependencies:
-    follow-redirects "^1.14.0"
+    follow-redirects "^1.14.4"
 
 babel-plugin-polyfill-corejs2@^0.3.3:
   version "0.3.3"
@@ -1985,7 +1985,7 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.1.tgz#bbef080d95fca6709362c73044a1634f7c6e7d05"
   integrity sha512-OMQjaErSFHmHqZe+PSidH5n8j3O0F2DdnVh8JB4j4eUQ2k6KvB0qGfrKIhapvez5JerBbmWkaLYUYWISaESoXg==
 
-follow-redirects@^1.14.0:
+follow-redirects@^1.14.4:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1120,10 +1120,10 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
 
-"@types/react@^17.0.2":
-  version "17.0.53"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.53.tgz#10d4d5999b8af3d6bc6a9369d7eb953da82442ab"
-  integrity sha512-1yIpQR2zdYu1Z/dc1OxC+MA6GR240u3gcnP4l6mvj/PJiVaqHsQPmWttsvHsfnhfPbU2FuGmo0wSITPygjBmsw==
+"@types/react@>=17":
+  version "18.2.12"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.12.tgz#95d584338610b78bb9ba0415e3180fb03debdf97"
+  integrity sha512-ndmBMLCgn38v3SntMeoJaIrO6tGHYKMEBohCUmw8HoLLQdRMOIGXfeYaBTLe2lsFaSB3MOK1VXscYFnmLtTSmw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -2866,13 +2866,12 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+react@>=17:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 read-pkg-up@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Закрывает задачу [SPECIAL-11013](https://youtrack.kts.studio/issue/SPECIAL-11013/mediaproject-vk-Dorabotat-biblioteku)

**Обновлено**:
- Дополнена обработка сообщений из VK API об отказе пользователя от какого-либо действия
- Исправлено определение window.notifications_enabled: ранее переменная всегда была равна true ([Соответствующий issue](https://github.com/ktsstudio/mediaproject-vk/issues/11))
- Исправлено определение переменных window.is_android и window.is_ios в mvk: ранее они всегда были undefined ([Соответствующий issue](https://github.com/ktsstudio/mediaproject-vk/issues/13))
- Исправлен набор переменных с названиями платформ, благодаря которым можно определить, что приложение открыто на Android ([Соответствующий issue](https://github.com/ktsstudio/mediaproject-vk/issues/14)). Плюс исправлена ошибка, возникающая из-за этого, связанная с тем, что на нативном приложении VK window.is_mvk становился равен true.
- Для библиотеки расширена поддержка react до версии 18 ([Соответствующий issue](https://github.com/ktsstudio/mediaproject-vk/issues/12))

**Новое**:
- Теперь для функции `callVkApi` можно указать дженерик-тип, обозначающий тип успешного ответа при обращении к API VK (методу VKWebAppCallAPIMethod vk-bridge): ранее тип ответа всегда был `any`. Тем не менее, если не указать дженерик, то тип так и останется `any`.

**Как тестировать**:
- **Проверка**. Опционально, можно убедиться в том, что, действительно, переменные window.notifications_enabled и window.is_android с window.is_ios (на мвк) определяются неверно. Хорошо, если у вас найдётся под рукой приложение, в котором можно переключать разрешение уведомлений. Можете вставить где-нибудь в коде – главное, чтобы это было после работы функций `checkVkPlatform` и `initializeVkApp` – логи наподобие тех, что ниже:
`console.log('window.notifications_enabled', window.notifications_enabled);`
`console.log(`
`    'findGetParameter("vk_are_notifications_enabled")',`
`    findGetParameter('vk_are_notifications_enabled'),`
`    typeof findGetParameter('vk_are_notifications_enabled')`
`);`
`console.log('window.is_ios', window.is_ios);`
`console.log('window.is_android', window.is_android);`
`console.log('window.is_mvk', window.is_mvk);`
Так, вы увидите следующую картину (смотри скриншоты ниже): на нативном андроиде `window.is_mvk` равен `true`, `window.is_android` равен `undefined`, на mvk android `window.is_android` равен `undefined`, на mvk ios `window.is_ios` равен `undefined`. Притом, `window.notifications_enabled` всегда `true`, несмотря на то, что параметр запуска "vk_are_notifications_enabled" равен строке "0", означающей, что уведомления отключены.
![compare1](https://github.com/ktsstudio/mediaproject-vk/assets/71431554/fac5e665-9d74-468d-b2cb-c8c4f9a02f78)
- **Как локально протестировать библиотеку**. Вам потребуется склонировать библиотеку и иметь тестовый проект. Для некоторых команд могут потребоваться права администратора, в таком случае припишите sudo перед командой (мак) или откройте терминал с правами администратора (винда)
  1. Склонировать ветку
  2. Внутри проекта с либой: `yarn build`
  3. Переместить/скопировать сформировавшуюся папку dist и package.json в нужный вам удобный каталог (вне каталога с тестовым проектом)
  4. Перейти в каталог, в который вы поместили dist
  5. `yarn install`
  6. `npm link <путь до проекта, в котором вы будете тестировать библиотеку>/node_modules/react` (Могут потребоваться права администратора). Эта команда нужна, чтобы при запуске проекта не произошло дублирование пакетов реакта, ломающее проект. Таким образом, собранная библиотека будет ссылаться на один экземпляр реакта – тот, который используется в тестовом проекте. Чтобы убедиться, что ссылка создана, пропишите команду `npm list -g --depth=0` и найдите в списке экземляр реакта, где путь указывает на пакет в составе вашего тестового проекта
  7. `yarn link` (По крайней мере при первом использовании могут потребоваться права). Этой командой вы создадите пакет, который можно будет использовать в тестовом проекте. Убедиться в том, что пакет заготовлен, можно, заглянув в корневую папку в каталог по пути ".config/yarn/link/@ktsstudio/mediaproject-vk" (по крайней мере на маке так; на маке это команда `ls ~/.config/yarn/link/@ktsstudio/mediaproject-vk`) – в каталоге должны быть такие же файлы, какие вы подготовили в каталоге с собранной либой
   8. Перейти в тестовый проект, прописать yarn link "@ktsstudio/mediaproject-vk" (могут потребоваться права администратора). Так, вы заставите yarn смотреть именно в заготовленный пакет с нужными изменениями
- **Проверка работоспособности**. После того, как вы привязали склонированную библиотеку к тестовому проекту, можете вызывать те же логи и убедиться в том, что всё работает, как ожидается (смотри скриншоты ниже: нативный андроид, мвк андроид, мвк ios соответственно). Плюс, можете попробовать указать дженерик-тип успешного ответа для функции `callVkApi`.
![compare2](https://github.com/ktsstudio/mediaproject-vk/assets/71431554/1c8e3641-dae7-4da6-a828-37463cfadab6)
- **Чтобы отвязать ссылку на заготовленный пакет**:
  1. Перейдите в каталог с собранной библиотекой
  2. `npm uninstall -g react` (могут потребоваться права администратора). Таким образом вы отвяжете реакт от собранной библиотеки
  3. yarn unlink (Могут потребоваться права администратора). Таким образом вы удалите заготовленный пакет. Убедиться в правильной работе можно, заглянув в корневую папку в каталог по пути ".config/yarn/link" (может присутствовать папка "@ktsstudio", но папки "mediaproject-vk" в ней быть не должно; путь до папки такой по крайней мере на маке, команда – `ls ~/.config/yarn/link`)
  4. На всякий случай пропишите в тестовом проекте yarn unlink "@ktsstudio/mediaproject-vk" (могут потребоваться права администратора), чтобы убрать ссылку на ранее заготовленный пакет, хотя yarn может ругнуться о том, что такого пакета нет.
  5. Внутри тестового проекта: `yarn install --force` чтобы восстановить зависимости
- **Посмотреть, не сломалась ли проверка того, отказался ли пользователь от какого-либо действия**, можно аналогичным образом. Например, отказ можно сделать в следующих сценариях: отказ предоставлять токен доступа к чему-либо, отказ шерить пост или историю, отказ скачивать картинку на нативном устройстве (если ранее вы сделали такую проверку).

